### PR TITLE
chore: rename project to equity-screener-mcp-server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 ## Setup
 
 ```bash
-git clone https://github.com/MatheusFernandesDuarte/yahoo-finance-regional-crawler.git
-cd yahoo-finance-regional-crawler
+git clone https://github.com/MatheusFernandesDuarte/equity-screener-mcp-server.git
+cd equity-screener-mcp-server
 uv sync
 uv run pytest tests/ -v    # verify everything passes
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 
-# 📈 Yahoo Finance Regional Crawler
+# 📈 Equity Screener MCP Server
 
 **Give your AI assistant real stock market data — from any country, in seconds.**
 
-[![CI](https://github.com/MatheusFernandesDuarte/yahoo-finance-regional-crawler/actions/workflows/ci.yml/badge.svg)](https://github.com/MatheusFernandesDuarte/yahoo-finance-regional-crawler/actions/workflows/ci.yml)
+[![CI](https://github.com/MatheusFernandesDuarte/equity-screener-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/MatheusFernandesDuarte/equity-screener-mcp-server/actions/workflows/ci.yml)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-enabled-7c3aed?logo=anthropic&logoColor=white)](https://modelcontextprotocol.io)
@@ -28,7 +28,7 @@ When you ask an AI assistant *"Which stocks spiked in Brazil today?"*, it either
 - ❌ Refuses: *"I don't have access to real-time data"*
 - ❌ Hallucinates: Makes up tickers with confident-sounding prices
 
-**This project solves that.** It scrapes Yahoo Finance equity data for any region, stores it locally in DuckDB, and exposes it as MCP tools that AI agents can call directly.
+**This project solves that.** It fetches equity screener data for any region, stores it locally in DuckDB, and exposes it as MCP tools that AI agents can call directly.
 
 ```
 You:    "Which stock spiked the most in Argentina today?"
@@ -58,8 +58,8 @@ Real data. No hallucinations. No browser needed.
 
 ```bash
 # 1. Clone the repo
-git clone https://github.com/MatheusFernandesDuarte/yahoo-finance-regional-crawler.git
-cd yahoo-finance-regional-crawler
+git clone https://github.com/MatheusFernandesDuarte/equity-screener-mcp-server.git
+cd equity-screener-mcp-server
 
 # 2. Install dependencies
 uv sync
@@ -80,7 +80,7 @@ Output goes to `data/outputs/` (CSV) and `data/market.duckdb`.
 ### Claude Code (recommended)
 
 ```bash
-claude mcp add yahoo-finance -- python /path/to/yahoo-finance-regional-crawler/mcp_server.py
+claude mcp add yahoo-finance -- python /path/to/equity-screener-mcp-server/mcp_server.py
 ```
 
 ### Claude Desktop
@@ -92,7 +92,7 @@ Add to `~/.claude/claude_desktop_config.json`:
   "mcpServers": {
     "yahoo-finance": {
       "command": "python",
-      "args": ["/path/to/yahoo-finance-regional-crawler/mcp_server.py"],
+      "args": ["/path/to/equity-screener-mcp-server/mcp_server.py"],
       "env": {
         "AI_PROVIDER": "local"
       }
@@ -108,7 +108,7 @@ Add to `~/.claude/claude_desktop_config.json`:
   "mcpServers": {
     "yahoo-finance": {
       "command": "python",
-      "args": ["/path/to/yahoo-finance-regional-crawler/mcp_server.py"],
+      "args": ["/path/to/equity-screener-mcp-server/mcp_server.py"],
       "env": {
         "AI_PROVIDER": "claude",
         "ANTHROPIC_API_KEY": "sk-ant-..."
@@ -188,8 +188,8 @@ python mcp_server.py
 └──────────────────────────────────────────────────────┘
           ↓ background thread
 ┌──────────────────────────────────────────────────────┐
-│  ScraperEngine  ──→  Yahoo Finance API  (HTTP)       │
-│     Auth: GET finance.yahoo.com → cookies → crumb    │
+│  ScraperEngine  ──→  Equity Screener API  (HTTP)     │
+│     Auth: GET screener host → cookies → crumb        │
 │     Data: POST /v1/finance/screener (JSON)           │
 │       ↓                                              │
 │  DuckDB  (writes, single lock)                       │
@@ -252,7 +252,7 @@ python mcp_server.py
 docker compose up
 
 # Custom region
-docker compose run yahoo-crawler python run.py Brazil
+docker compose run equity-screener python run.py Brazil
 
 # MCP server via HTTP (for remote clients)
 MCP_TRANSPORT=http MCP_PORT=8000 docker compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
-  yahoo-crawler:
+  equity-screener:
     build:
       context: .
       dockerfile: Dockerfile
-    image: yahoo-crawler:latest
-    container_name: yahoo_finance_crawler
+    image: equity-screener:latest
+    container_name: equity_screener
     volumes:
       - ./data/outputs:/app/data/outputs
     environment:

--- a/examples/mcp_config.json
+++ b/examples/mcp_config.json
@@ -3,7 +3,7 @@
     "yahoo-finance": {
       "command": "python",
       "args": ["mcp_server.py"],
-      "cwd": "/path/to/yahoo-finance-regional-crawler",
+      "cwd": "/path/to/equity-screener-mcp-server",
       "env": {
         "MCP_TRANSPORT": "stdio",
         "AI_PROVIDER": "local"

--- a/examples/mcp_config_with_claude.json
+++ b/examples/mcp_config_with_claude.json
@@ -3,7 +3,7 @@
     "yahoo-finance": {
       "command": "python",
       "args": ["mcp_server.py"],
-      "cwd": "/path/to/yahoo-finance-regional-crawler",
+      "cwd": "/path/to/equity-screener-mcp-server",
       "env": {
         "MCP_TRANSPORT": "stdio",
         "AI_PROVIDER": "claude",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
-name = "yahoo-finance-regional-crawler"
+name = "equity-screener-mcp-server"
 version = "0.1.0"
-description = "AI-native, MCP-enabled regional stock data service powered by Yahoo Finance"
+description = "AI-native, MCP-enabled regional equity screener with DuckDB persistence"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
-keywords = ["yahoo-finance", "mcp", "stocks", "scraper", "ai"]
+keywords = ["equity-screener", "mcp", "stocks", "finance", "ai"]
 dependencies = [
     "anthropic>=0.40.0",
     "bs4>=0.0.2",

--- a/uv.lock
+++ b/uv.lock
@@ -477,6 +477,37 @@ wheels = [
 ]
 
 [[package]]
+name = "equity-screener-mcp-server"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "anthropic" },
+    { name = "bs4" },
+    { name = "duckdb" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "openai" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "python-dotenv" },
+    { name = "requests" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "bs4", specifier = ">=0.0.2" },
+    { name = "duckdb", specifier = ">=1.1.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
+    { name = "openai", specifier = ">=1.0.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "requests", specifier = ">=2.32.0" },
+    { name = "ruff", specifier = ">=0.4.0" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1316,35 +1347,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
-]
-
-[[package]]
-name = "yahoo-finance-regional-crawler"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "anthropic" },
-    { name = "bs4" },
-    { name = "duckdb" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "openai" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "python-dotenv" },
-    { name = "requests" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", specifier = ">=0.40.0" },
-    { name = "bs4", specifier = ">=0.0.2" },
-    { name = "duckdb", specifier = ">=1.1.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
-    { name = "openai", specifier = ">=1.0.0" },
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "python-dotenv", specifier = ">=1.2.1" },
-    { name = "requests", specifier = ">=2.32.0" },
-    { name = "ruff", specifier = ">=0.4.0" },
 ]


### PR DESCRIPTION
## Summary
- Update project name in pyproject.toml, README.md, CONTRIBUTING.md, docker-compose.yml e example configs
- Repo URL references updated to equity-screener-mcp-server